### PR TITLE
Using a more up-to-date jdk image

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -135,7 +135,7 @@ task createDockerfile(type: Dockerfile, dependsOn: prepareDocker) { // <4>
 
     destFile = project.file("${dockerBuildDir}/Dockerfile")
 
-    from 'openjdk:8u151-jdk-alpine'
+    from 'adoptopenjdk/openjdk8:jdk8u232-b09-alpine'
 
     exposePort 8080
 

--- a/src/main/docs/guide/building.adoc
+++ b/src/main/docs/guide/building.adoc
@@ -14,7 +14,7 @@ After creating the new Gradle tasks, now we can execute:
 :complete:buildImage # <2>
 Building image using context '/home/ivan/workspaces/oci/guides/grails-as-docker-container/complete/build/docker'.
 Using tag 'grails-sample/complete:0.1' for image.
-Step 1/8 : FROM openjdk:8u151-jdk-alpine
+Step 1/8 : FROM adoptopenjdk/openjdk8:jdk8u232-b09-alpine
 ---> 3642e636096d
 Step 2/8 : MAINTAINER John Doe "john.doe@example.com"
 ---> Using cache

--- a/src/main/docs/guide/usingOnlyDocker.adoc
+++ b/src/main/docs/guide/usingOnlyDocker.adoc
@@ -8,7 +8,7 @@ Alternatively, you can create a Docker file manually.
 [source, Dockerfile]
 .src/main/docker/Dockerfile
 ----
-FROM openjdk:8u151-jdk-alpine
+FROM adoptopenjdk/openjdk8:jdk8u232-b09-alpine
 MAINTAINER John Doe "john.doe@example.com"
 
 EXPOSE 8080


### PR DESCRIPTION
Right now the official openjdk (witch uses [adoptopenjdk](https://github.com/docker-library/openjdk/blob/dae43871681682fb03dc9f767d2d161105f7f8e0/8/jdk/slim/Dockerfile#L22)) repository in docker hub doesn't contains alpine images for jdk 8. The alpine images now rest only in adoptopenjdk/openjdk8.